### PR TITLE
emulation: fixing tempdir path

### DIFF
--- a/src/emulation/emulatorhandler.cpp
+++ b/src/emulation/emulatorhandler.cpp
@@ -144,7 +144,7 @@ void EmulatorHandler::startEmulator(QDir romDir, QString romFileName, QString zi
         romData.append(zippedFile.readAll());
         zippedFile.close();
 
-        QString tempDir = QDir::tempPath() + "/" + AppNameLower + "/" + qgetenv("USER");
+        QString tempDir = QDir::tempPath() + "/" + AppNameLower + "-" + qgetenv("USER");
         QDir().mkpath(tempDir);
         completeRomPath = tempDir + "/temp.n64";
 


### PR DESCRIPTION
In a multiuser environment, the program will crate a temporary folder structure
like:

/tmp/mupen64plus-qt/user1/
/tmp/mupen64plus-qt/user2/

This is wrong, because user permission for the containing folder are the ones
from the first user and any successive user will encounter an error accessing
it.

This patch fixes the problem let the application creating a folder for each user
like:

/tmp/mupen64plus-qt-user1/